### PR TITLE
Fix CommonUtils.sleep(): sleep period was fixed

### DIFF
--- a/src/main/java/org/jtransforms/utils/CommonUtils.java
+++ b/src/main/java/org/jtransforms/utils/CommonUtils.java
@@ -67,7 +67,7 @@ public class CommonUtils
     public static void sleep(long millis)
     {
         try {
-            Thread.sleep(5000);
+            Thread.sleep(millis);
         } catch (InterruptedException e) {
             e.printStackTrace();
         }


### PR DESCRIPTION
sleep() should sleep "millis" milliseconds, not 5000.